### PR TITLE
Remove surrounding navBarTitle div and Fix text decoration of NavBar title

### DIFF
--- a/app/navbar.css
+++ b/app/navbar.css
@@ -13,6 +13,8 @@
     font-size: 35px;
     font-weight: 600;
     margin-bottom: 20px;
+    text-decoration: none;
+    line-height: 1;
 }
 
 .navBarItemsContainer {

--- a/app/navbar.js
+++ b/app/navbar.js
@@ -9,9 +9,7 @@ export function NavBar() {
 
     return (
         <div className="navBarContainer">
-            <div className="navBarTitle">
-                <Link className="title" href="/">Unitrack</Link>
-            </div>
+            <Link className="navBarTitle" href="/">Unitrack</Link>
             <div className="navBarItemsContainer">
                 <button className="navBarButton navBarItem" onClick={() => router.push("/degreePlanner")}>
                     <i className="material-icons">edit_calendar</i>&nbsp;&nbsp;


### PR DESCRIPTION
# Remove surrounding navBarTitle div and simplify into just the link component

TLDR: You've added a wrapper div, I just removed it and fixed the text underline issue.

**First Note - try not to touch `reset.css` for reason unrelated to _reseting_. `reset.css` just removes any underlying css that browsers provide.** If you would like to remove underline (font text decoration then just create a new class that has that css).

Remember a general rule.
**Overrides**
- ID CSS
- Class CSS
- A Second Class CSS Applied to same element
- Element CSS 

**Gets Overridden**  

Also only add a surrounding div if 
- The component is complex. In this context imagine the navbar title contained some emojis and an image it would be more complex to manage all the components that the title has.
- There is some management of padding or margins you need specific to having a wrapper.
- A few other reasons I can't think of rn ;-;

Otherwise having a wrapper just complicates code, and hurts readability.

Another general rule is that all CSS is passed down to child divs so that usually means that we can move a lot of the work up or down, whichever makes life easier.

**Before**
![image](https://github.com/GoodGameRuler/unitrack_v3/assets/85796687/71fca669-a671-4292-90d9-41bc2830e41f)


**After**
![image](https://github.com/GoodGameRuler/unitrack_v3/assets/85796687/10d097c3-c66d-4a06-9b98-93a79af65349)
