### PR TITLE
Fix React warning: use defaultValue instead of selected

### DIFF
--- a/app/degreePlanner/degreePlanner.css
+++ b/app/degreePlanner/degreePlanner.css
@@ -44,7 +44,3 @@
     background-position: right 0.8rem center;
     background-size: 1em;
 }
-
-.formElement .degreeSelect:invalid {
-    color: #999;
-}

--- a/app/degreePlanner/page.jsx
+++ b/app/degreePlanner/page.jsx
@@ -14,8 +14,8 @@ function DegreePlanner() {
                 <div className="detailsForm">
                     <div className="formElement">
                         <label className="degreeLabel" htmlFor="degree">Degree</label>
-                        <select id="degree" className="degreeSelect" required>
-                            <option value="" disabled selected>Select degree</option>
+                        <select id="degree" className="degreeSelect" defaultValue="0" required>
+                            <option value="0" disabled>Select degree</option>
                             <option value="1">Bachelor of Science</option>
                             <option value="2">Bachelor of Advanced Computing</option>
                             <option value="3">Bachelor of Interaction Design/Bachelor of Advanced Studies</option>
@@ -23,8 +23,8 @@ function DegreePlanner() {
                     </div>
                     <div className="formElement">
                         <label className="degreeLabel" htmlFor="firstMajor">Major</label>
-                        <select id="firstMajor" className="degreeSelect" required>
-                            <option value="" disabled selected>Select major</option>
+                        <select id="firstMajor" className="degreeSelect" defaultValue="0" required>
+                            <option value="0" disabled>Select major</option>
                             <option value="1">Computer Science</option>
                             <option value="2">Data Science</option>
                             <option value="3">Development</option>
@@ -33,7 +33,6 @@ function DegreePlanner() {
                     <div className="formElement">
                         <label className="degreeLabel" htmlFor="secondMajor">Second major (if applicable)</label>
                         <select id="secondMajor" className="degreeSelect" defaultValue="4" required>
-                            <option value="" disabled selected>Select major</option>
                             <option value="1">Computer Science</option>
                             <option value="2">Data Science</option>
                             <option value="3">Software Development</option>
@@ -43,7 +42,6 @@ function DegreePlanner() {
                     <div className="formElement">
                         <label className="degreeLabel" htmlFor="minor">Minor (if applicable)</label>
                         <select id="minor" className="degreeSelect" defaultValue="4" required>
-                            <option value="" disabled selected>Select minor</option>
                             <option value="1">Mathematics</option>
                             <option value="2">Computer Science</option>
                             <option value="3">Design</option>


### PR DESCRIPTION
Fix #65. The only downside with this is that it's too complex to change the selected defaultValue to grey as seen previously. However, it is not consistent with the default values set for optional inputs. Also removed unnecessary CSS and code from fix #36.

Before:
<img width="506" alt="Screenshot 2024-06-01 at 10 59 25 PM" src="https://github.com/GoodGameRuler/unitrack_v3/assets/63948459/7292ce0b-9a36-4410-8ef1-04c680d534eb">

After:
<img width="498" alt="Screenshot 2024-06-01 at 11 00 14 PM" src="https://github.com/GoodGameRuler/unitrack_v3/assets/63948459/f333e29e-6b2c-4572-b7bb-53792f0570fa">

 